### PR TITLE
Feature/s5 jest.fn mock mongoose model

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 1. shopping-list.controller.test.js: require ShopItemModel
 2. Use jest.fn() to mock mongoose create method
 3. create new test: it "should call ShopItemModel.create" - check console: to confirm the test failed
+4. shopping-list.controller.js: invoke ShopItemModel.create() inside the addItem() - observe test is passing
+5. Observe Mongoose "console.warn", follow the step mentioned in the url to enable node test environement. create jest.config.js in the root folder and add the mentioned content.
+6. re-run the test and confirm the warning is gone

--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 2. npm install mongoose --save
 3. Create schema /database/models/ShopItem.js
 4. ShopItem.js: define ShopItemSchema and export ShopItemModel 
+
+# s5-jest.fn-mock-mongoose-model
+1. shopping-list.controller.test.js: require ShopItemModel
+2. Use jest.fn() to mock mongoose create method
+3. create new test: it "should call ShopItemModel.create" - check console: to confirm the test failed

--- a/api/controller/shopping-list.controller.js
+++ b/api/controller/shopping-list.controller.js
@@ -1,1 +1,5 @@
-exports.addItem = () => {}
+const ShopItemModel = require("../../database/models/ShopItem");
+
+exports.addItem = () => {
+    ShopItemModel.create();
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    testEnvironment: 'node'
+};

--- a/test/unit/shopping-list.controller.test.js
+++ b/test/unit/shopping-list.controller.test.js
@@ -1,8 +1,15 @@
 const { it, expect } = require("@jest/globals");
 const ShoppingListController = require("../../api/controller/shopping-list.controller");
+const ShopItemModel = require("../../database/models/ShopItem");
+
+ShopItemModel.create = jest.fn();
 
 describe("ShoppingListController.addItem", () => {
     it("should have a addItem function", () => {
         expect(typeof ShoppingListController.addItem).toBe("function");
+    })
+    it("should call ShopItemModel.create", () => {
+        ShoppingListController.addItem();
+        expect(ShopItemModel.create).toBeCalled();
     })
 })


### PR DESCRIPTION
# s5-jest.fn-mock-mongoose-model
1. shopping-list.controller.test.js: require ShopItemModel
2. Use jest.fn() to mock mongoose create method
3. create new test: it "should call ShopItemModel.create" - check console: to confirm the test failed
4. shopping-list.controller.js: invoke ShopItemModel.create() inside the addItem() - observe test is passing
5. Observe Mongoose "console.warn", follow the step mentioned in the url to enable node test environement. create jest.config.js in the root folder and add the mentioned content.
6. re-run the test and confirm the warning is gone