### PR TITLE
Feature/s6 setup node mocks http to mock req res next

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,10 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 4. shopping-list.controller.js: invoke ShopItemModel.create() inside the addItem() - observe test is passing
 5. Observe Mongoose "console.warn", follow the step mentioned in the url to enable node test environement. create jest.config.js in the root folder and add the mentioned content.
 6. re-run the test and confirm the warning is gone
+
+# s6-setup-node-mocks-http-to-mock-req-res-next
+1. npm install node-mocks-http --save-dev
+2. shopping-list.controller.test.js: setup node-mocks-http and mock req, res
+3. Create ./test/mock-data/shop-item.json mock data file and use it in the test.
+4. Modify the test to pass req, res, next in ShoppingListController.addItem(req, res, next) 
+5. Observe the test is failing, modify shopping-list.controller.js to accept req, res, next params

--- a/README.md
+++ b/README.md
@@ -43,3 +43,5 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 3. Create ./test/mock-data/shop-item.json mock data file and use it in the test.
 4. Modify the test to pass req, res, next in ShoppingListController.addItem(req, res, next) 
 5. Observe the test is failing, modify shopping-list.controller.js to accept req, res, next params
+6. Update .toBeCalled() to alledWith(newShopItem): monitor the test is failing.
+7. shopping-list.controller.js: pass req.body to ShopItemModel.create and test will pass now

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 5. Observe the test is failing, modify shopping-list.controller.js to accept req, res, next params
 6. Update .toBeCalled() to alledWith(newShopItem): monitor the test is failing.
 7. shopping-list.controller.js: pass req.body to ShopItemModel.create and test will pass now
+8. Create a new test to validate HTTP response code 201. it "should return HTTP response 201" test should fail at this time.
+9. shopping-list.controller.js: add following - res.status(201) to make the test pass
+10. To ensure response it send back modify the test and expect res._isEndCalled() toBeTruthy: test should fail at this moment.
+11. shopping-list.controller.js: res.status(201).send() append send() - all test should pass at this moment.

--- a/api/controller/shopping-list.controller.js
+++ b/api/controller/shopping-list.controller.js
@@ -1,5 +1,5 @@
 const ShopItemModel = require("../../database/models/ShopItem");
 
 exports.addItem = (req, res, next) => {
-    ShopItemModel.create();
+    ShopItemModel.create(req.body);
 }

--- a/api/controller/shopping-list.controller.js
+++ b/api/controller/shopping-list.controller.js
@@ -1,5 +1,5 @@
 const ShopItemModel = require("../../database/models/ShopItem");
 
-exports.addItem = () => {
+exports.addItem = (req, res, next) => {
     ShopItemModel.create();
 }

--- a/api/controller/shopping-list.controller.js
+++ b/api/controller/shopping-list.controller.js
@@ -2,4 +2,5 @@ const ShopItemModel = require("../../database/models/ShopItem");
 
 exports.addItem = (req, res, next) => {
     ShopItemModel.create(req.body);
+    res.status(201).send();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3553,6 +3553,23 @@
       "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
       "dev": true
     },
+    "node-mocks-http": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/node-mocks-http/-/node-mocks-http-1.10.1.tgz",
+      "integrity": "sha512-/Nz83kiJ3z+vGqxmlDyv8+L1CJno+gH23DzG3oPH9dBSfMYa5IFVwPgZpXCB2kdiiIu/HoDpZ2BuLqQs7qjFLQ==",
+      "dev": true,
+      "requires": {
+        "accepts": "^1.3.7",
+        "depd": "^1.1.0",
+        "fresh": "^0.5.2",
+        "merge-descriptors": "^1.0.1",
+        "methods": "^1.1.2",
+        "mime": "^1.3.4",
+        "parseurl": "^1.3.3",
+        "range-parser": "^1.2.0",
+        "type-is": "^1.6.18"
+      }
+    },
     "node-modules-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "mongoose": "^5.12.2"
   },
   "devDependencies": {
-    "jest": "^26.6.3"
+    "jest": "^26.6.3",
+    "node-mocks-http": "^1.10.1"
   },
   "scripts": {
     "test": "jest --watchAll"

--- a/test/mock-data/shop-item.json
+++ b/test/mock-data/shop-item.json
@@ -1,0 +1,4 @@
+{
+    "name": "Milk",
+    "buy": true
+}

--- a/test/unit/shopping-list.controller.test.js
+++ b/test/unit/shopping-list.controller.test.js
@@ -19,6 +19,6 @@ describe("ShoppingListController.addItem", () => {
         req.body = newShopItem;
 
         ShoppingListController.addItem(req, res, next);
-        expect(ShopItemModel.create).toBeCalled();
+        expect(ShopItemModel.create).toBeCalledWith(newShopItem);
     })
 })

--- a/test/unit/shopping-list.controller.test.js
+++ b/test/unit/shopping-list.controller.test.js
@@ -1,6 +1,9 @@
 const { it, expect } = require("@jest/globals");
+const httpMocks = require("node-mocks-http");
+
 const ShoppingListController = require("../../api/controller/shopping-list.controller");
 const ShopItemModel = require("../../database/models/ShopItem");
+const newShopItem = require("../mock-data/shop-item.json");
 
 ShopItemModel.create = jest.fn();
 
@@ -9,7 +12,13 @@ describe("ShoppingListController.addItem", () => {
         expect(typeof ShoppingListController.addItem).toBe("function");
     })
     it("should call ShopItemModel.create", () => {
-        ShoppingListController.addItem();
+        let req, res, next;
+        req = httpMocks.createRequest();
+        res = httpMocks.createResponse();
+        next= null;
+        req.body = newShopItem;
+
+        ShoppingListController.addItem(req, res, next);
         expect(ShopItemModel.create).toBeCalled();
     })
 })

--- a/test/unit/shopping-list.controller.test.js
+++ b/test/unit/shopping-list.controller.test.js
@@ -21,4 +21,14 @@ describe("ShoppingListController.addItem", () => {
         ShoppingListController.addItem(req, res, next);
         expect(ShopItemModel.create).toBeCalledWith(newShopItem);
     })
+    it("should return HTTP response 201", () => {
+        let req, res, next;
+        req = httpMocks.createRequest();
+        res = httpMocks.createResponse();
+        next= null;
+        req.body = newShopItem;
+        ShoppingListController.addItem(req, res, next);
+        expect(res.statusCode).toBe(201);
+        expect(res._isEndCalled()).toBeTruthy();
+    })
 })


### PR DESCRIPTION
# s6-setup-node-mocks-http-to-mock-req-res-next
1. npm install node-mocks-http --save-dev
2. shopping-list.controller.test.js: setup node-mocks-http and mock req, res
3. Create ./test/mock-data/shop-item.json mock data file and use it in the test.
4. Modify the test to pass req, res, next in ShoppingListController.addItem(req, res, next) 
5. Observe the test is failing, modify shopping-list.controller.js to accept req, res, next params
6. Update .toBeCalled() to alledWith(newShopItem): monitor the test is failing.
7. shopping-list.controller.js: pass req.body to ShopItemModel.create and test will pass now
8. Create a new test to validate HTTP response code 201. it "should return HTTP response 201" test should fail at this time.
9. shopping-list.controller.js: add following - res.status(201) to make the test pass
10. To ensure response it send back modify the test and expect res._isEndCalled() toBeTruthy: test should fail at this moment.
11. shopping-list.controller.js: res.status(201).send() append send() - all test should pass at this moment.