### PR TITLE
Feature/s7 test to validate response has new shop item and refactor using before each

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 2. extract request.body to beforeEach of describe
 3. it "should return json body in response": use mockReturnValue to mock the response whenever the respective method is called.
 4. use _getJSONData() on res to get the data from the response. At this moment observe the test is failing.
+5. shopping-list.controller.js: modify the addItem method and return savedItem in json format by changing .send() to .json(savedItem)
+6. Observe the test is still failing.

--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 
 # s7-test-to-validate-response-has-new-shop-item-and-refactor-using-beforeEach
 1. shopping-list.controller.test.js: extract req, res and next to global beforeEach
+2. extract request.body to beforeEach of describe

--- a/README.md
+++ b/README.md
@@ -53,3 +53,5 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 # s7-test-to-validate-response-has-new-shop-item-and-refactor-using-beforeEach
 1. shopping-list.controller.test.js: extract req, res and next to global beforeEach
 2. extract request.body to beforeEach of describe
+3. it "should return json body in response": use mockReturnValue to mock the response whenever the respective method is called.
+4. use _getJSONData() on res to get the data from the response. At this moment observe the test is failing.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 9. shopping-list.controller.js: add following - res.status(201) to make the test pass
 10. To ensure response it send back modify the test and expect res._isEndCalled() toBeTruthy: test should fail at this moment.
 11. shopping-list.controller.js: res.status(201).send() append send() - all test should pass at this moment.
+
+# s7-test-to-validate-response-has-new-shop-item-and-refactor-using-beforeEach
+1. shopping-list.controller.test.js: extract req, res and next to global beforeEach

--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ TDD approach to write Unit/ Integartion using Jest/ Supertest for Express REST A
 4. use _getJSONData() on res to get the data from the response. At this moment observe the test is failing.
 5. shopping-list.controller.js: modify the addItem method and return savedItem in json format by changing .send() to .json(savedItem)
 6. Observe the test is still failing.
+7. Test is still failing because the memory of expected object and the response object are different. Use toStrictEqual in test instead of toBe to validate the response 

--- a/api/controller/shopping-list.controller.js
+++ b/api/controller/shopping-list.controller.js
@@ -1,6 +1,6 @@
 const ShopItemModel = require("../../database/models/ShopItem");
 
 exports.addItem = (req, res, next) => {
-    ShopItemModel.create(req.body);
-    res.status(201).send();
+    const savedItem = ShopItemModel.create(req.body);
+    res.status(201).json(savedItem);
 }

--- a/test/unit/shopping-list.controller.test.js
+++ b/test/unit/shopping-list.controller.test.js
@@ -30,4 +30,9 @@ describe("ShoppingListController.addItem", () => {
         expect(res.statusCode).toBe(201);
         expect(res._isEndCalled()).toBeTruthy();
     })
+    it("should return json body in response", () => {
+        ShopItemModel.create.mockReturnValue(newShopItem);
+        ShoppingListController.addItem(req, res, next);
+        expect(res._getJSONData()).toBe(newShopItem);
+    })
 })

--- a/test/unit/shopping-list.controller.test.js
+++ b/test/unit/shopping-list.controller.test.js
@@ -33,6 +33,6 @@ describe("ShoppingListController.addItem", () => {
     it("should return json body in response", () => {
         ShopItemModel.create.mockReturnValue(newShopItem);
         ShoppingListController.addItem(req, res, next);
-        expect(res._getJSONData()).toBe(newShopItem);
+        expect(res._getJSONData()).toStrictEqual(newShopItem);
     })
 })

--- a/test/unit/shopping-list.controller.test.js
+++ b/test/unit/shopping-list.controller.test.js
@@ -1,4 +1,4 @@
-const { it, expect } = require("@jest/globals");
+const { it, expect, beforeEach } = require("@jest/globals");
 const httpMocks = require("node-mocks-http");
 
 const ShoppingListController = require("../../api/controller/shopping-list.controller");
@@ -7,25 +7,23 @@ const newShopItem = require("../mock-data/shop-item.json");
 
 ShopItemModel.create = jest.fn();
 
+let req, res, next;
+beforeEach(() => {
+    req = httpMocks.createRequest();
+    res = httpMocks.createResponse();
+    next= null;
+})
+
 describe("ShoppingListController.addItem", () => {
     it("should have a addItem function", () => {
         expect(typeof ShoppingListController.addItem).toBe("function");
     })
     it("should call ShopItemModel.create", () => {
-        let req, res, next;
-        req = httpMocks.createRequest();
-        res = httpMocks.createResponse();
-        next= null;
         req.body = newShopItem;
-
         ShoppingListController.addItem(req, res, next);
         expect(ShopItemModel.create).toBeCalledWith(newShopItem);
     })
     it("should return HTTP response 201", () => {
-        let req, res, next;
-        req = httpMocks.createRequest();
-        res = httpMocks.createResponse();
-        next= null;
         req.body = newShopItem;
         ShoppingListController.addItem(req, res, next);
         expect(res.statusCode).toBe(201);

--- a/test/unit/shopping-list.controller.test.js
+++ b/test/unit/shopping-list.controller.test.js
@@ -15,16 +15,17 @@ beforeEach(() => {
 })
 
 describe("ShoppingListController.addItem", () => {
+    beforeEach(() => {
+        req.body = newShopItem;
+    })
     it("should have a addItem function", () => {
         expect(typeof ShoppingListController.addItem).toBe("function");
     })
     it("should call ShopItemModel.create", () => {
-        req.body = newShopItem;
         ShoppingListController.addItem(req, res, next);
         expect(ShopItemModel.create).toBeCalledWith(newShopItem);
     })
     it("should return HTTP response 201", () => {
-        req.body = newShopItem;
         ShoppingListController.addItem(req, res, next);
         expect(res.statusCode).toBe(201);
         expect(res._isEndCalled()).toBeTruthy();


### PR DESCRIPTION
# s7-test-to-validate-response-has-new-shop-item-and-refactor-using-beforeEach
1. shopping-list.controller.test.js: extract req, res and next to global beforeEach
2. extract request.body to beforeEach of describe
3. it "should return json body in response": use mockReturnValue to mock the response whenever the respective method is called.
4. use _getJSONData() on res to get the data from the response. At this moment observe the test is failing.
5. shopping-list.controller.js: modify the addItem method and return savedItem in json format by changing .send() to .json(savedItem)
6. Observe the test is still failing.
7. Test is still failing because the memory of expected object and the response object are different. Use toStrictEqual in test instead of toBe to validate the response 